### PR TITLE
Dependencies version updates and corrections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: ruby
 rvm:
-  - 2.1.1
-  - 2.1.0
-  - 2.0.0
-  - 1.9.3
-  - jruby-18mode
-  - jruby-19mode
-  - 1.8.7
-  - ree
+  - 2.7.0
+  - 2.5.8
+  - 2.3.8
+  - jruby-1.7.27
 script: "bundle exec rspec"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.3.0
+~ Update minimum ruby version to 2.3.8
+~ Updated license to Apache License 2.0
+
 0.2.2
 ~ A MethodStruct class now implements #to_proc and so can be passed as a block
 	argument

--- a/lib/method_struct/version.rb
+++ b/lib/method_struct/version.rb
@@ -1,3 +1,3 @@
 module MethodStruct
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end

--- a/method_struct.gemspec
+++ b/method_struct.gemspec
@@ -11,14 +11,20 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Facilitates extracting methods into separate objects}
   spec.summary       = %q{Facilitates extracting methods into separate objects}
   spec.homepage      = "https://github.com/basecrm/method_struct"
-  spec.license       = "Apache License Version 2.0"
+  spec.license       = "Apache-2.0"
+
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  if RUBY_PLATFORM =~ /java/
+    spec.required_ruby_version = ">= 1.7.27"
+  else 
+    spec.required_ruby_version = ">= 2.3.8"
+  end
+  
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 2.14.1"
 end

--- a/method_struct.gemspec
+++ b/method_struct.gemspec
@@ -6,7 +6,7 @@ require 'method_struct/version'
 Gem::Specification.new do |spec|
   spec.name          = "method_struct"
   spec.version       = MethodStruct::VERSION
-  spec.authors       = ["Zendesk"]
+  spec.authors       = ["Zendesk", "Paweł Obrok"]
   spec.email         = ["opensource@zendesk.com"]
   spec.description   = %q{Facilitates extracting methods into separate objects}
   spec.summary       = %q{Facilitates extracting methods into separate objects}


### PR DESCRIPTION
This PR is maintenance to keep the code ready to be updated. No gem logic change is made.

* Removed Gemfile.lock to support multiple versions of ruby in CI. Generally gems do not store Gemfile.lock.
* Updated travis ruby versions to start from 2.3.8 (last 2.3 version). Even tho this version is already discontinued by ruby, some users may still use this gem with this ruby versions.
* Updated minimum version in gemspec, to align it with versions we test.
* Updated version to 0.3.0